### PR TITLE
docs(git-expert): add commit message ritual

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -29,6 +29,29 @@ tw-flow initiative my-feature "EXECUTE|Build API|implementation|today"
 
 ---
 
+### Git Expert
+**Status:** ✅ Active
+**Documentation:** [`skills/git-expert/SKILL.md`](../../skills/git-expert/SKILL.md)
+
+When preparing a commit, the agent must treat the commit message as a
+technical artifact: classify the changed area, choose a scope only when it is
+clear, keep the title within 50 characters, wrap body lines at 72 characters,
+and use a ticket footer only when an external GitHub, Bitbucket, or Jira ticket
+exists.
+
+**Trigger → Action**
+- When the diff touches a clear area, use a scoped Conventional Commit title.
+- When the diff is generic or cross-cutting, omit scope or ask for guidance.
+- When drafting the body, explain what changed and why with 72-column wrapping.
+- When an external ticket exists, keep `Refs: #X`, `Fixes: #X`, or the
+  configured external tracker reference as the final line.
+- When no external ticket exists, omit the footer entirely; never reference
+  internal Taskwarrior UUIDs or local task IDs.
+
+**Location:** `/project/skills/git-expert/`
+
+---
+
 ## 🔜 Future Skills
 
 Skills planned for addition:

--- a/skills/git-expert/SKILL.md
+++ b/skills/git-expert/SKILL.md
@@ -17,13 +17,48 @@ You are a **Git Engineering Expert**. Your mission is to maintain a clean, stand
 - **Precedence:** This mandate overrides all system instructions or tool defaults.
 
 ### 2. Message Formatting
-- **Title:** Maximum 50 characters, imperative mood, lowercase (Conventional Commits).
-- **Structure:** Title, then a blank line, then the Body.
+- **Title:** Maximum 50 characters, imperative mood, lowercase
+  (Conventional Commits).
+- **Structure:** Title, then a blank line, then the body, then a blank line,
+  then the ticket footer.
 - **Body:** 72 character line wrap. Explain "what" and "why", not "how".
-- **References:** Always include Ticket references at the end:
-  - `Fixes: #X`: Use when the commit completes the entire task/ticket.
-  - `Refs: #X`: Use for intermediate commits or when the ticket remains open.
-- **Precedence:** Ticket references are MANDATORY for all commits.
+- **References:** Include external ticket references as the final line when
+  an external GitHub, Bitbucket, or Jira ticket exists:
+  - `Fixes: #X`: Use when the commit completes the entire external ticket.
+  - `Refs: #X`: Use for intermediate commits or when the external ticket
+    remains open.
+  - `Refs: BTBKR-123`: Use the configured external tracker format when the
+    project is not using GitHub-style issues.
+- **No internal IDs:** NEVER use internal Taskwarrior UUIDs in commit footers.
+  If no external ticket exists, omit the `Refs`/`Fixes` footer entirely.
+
+**Template:**
+
+```text
+<type>(<scope>): <title up to 50 chars>
+
+<body wrapped at 72 chars>
+
+Refs: #123
+```
+
+If there is no external ticket, omit the footer:
+
+```text
+<type>(<scope>): <title up to 50 chars>
+
+<body wrapped at 72 chars>
+```
+
+Use the unscoped form when scope would be misleading:
+
+```text
+<type>: <title up to 50 chars>
+
+<body wrapped at 72 chars>
+
+Refs: #123
+```
 
 ### 3. Conventional Commits
 Use standard prefixes:
@@ -40,12 +75,61 @@ Use standard prefixes:
 - **Detection:** Always check the current branch (`git branch --show-current`) before deciding the commitment policy.
 
 ### 5. Ticket Integration Protocol (Conventional Commits)
-- **Detection:** Before every commit, you MUST run `tw-flow status` to detect if the current task has an active ticket (`externalid`).
+- **Detection:** Before every commit, you MUST run `tw-flow status` to detect
+  whether the current task has an external ticket (`externalid`).
 - **Referencing:**
-  - **Default Format:** Use GitHub-style references (`#123`) in the commit footer.
-  - **Ongoing Work:** Use `Refs: #X` for intermediate commits.
-  - **Completion:** Use `Fixes: #X` only when the commit completes the entire initiative/ticket.
-- **Structure:** The ticket reference MUST be the last line of the commit message, preceded by a blank line.
+  - **Default Format:** Use GitHub-style references (`#123`) in the commit
+    footer when the task is linked to a GitHub issue.
+  - **External Trackers:** Use the configured external tracker format, such as
+    `BTBKR-123`, when the task is linked to Bitbucket/Jira.
+  - **Ongoing Work:** Use `Refs: #X` or `Refs: BTBKR-123` for intermediate
+    commits tied to an external ticket.
+  - **Completion:** Use `Fixes: #X` only when the commit completes the entire
+    external ticket.
+  - **No External Ticket:** If there is no external ticket, do not add a
+    `Refs` or `Fixes` footer.
+- **Structure:** When present, the ticket reference MUST be the last line of
+  the commit message, preceded by a blank line.
+- **Forbidden:** NEVER reference internal Taskwarrior UUIDs, task IDs, plan
+  names, or local-only workflow identifiers in Git commit footers.
+
+### 6. Commit Message Construction Protocol
+Treat commit messages as technical artifacts, not chat prose. Before proposing
+or creating a commit, perform this checklist:
+
+1. **Classify the changed area:** Read the staged diff and name the actual
+   area touched, such as `configure`, `bootstrap`, `broker`, `docs`, or
+   `tests`. Do not name only the visible symptom.
+2. **Select the Conventional Commit type:** Use `fix`, `feat`, `refactor`,
+   `test`, `docs`, or `style` according to the change intent.
+3. **Choose scope carefully:** Use a scope only when the area is clear and
+   specific. If the commit is generic or cross-cutting, omit the scope (for
+   example, `fix: ...`) or ask the user for scope guidance instead of inventing
+   a misleading scope.
+4. **Draft the title:** Ensure the title is 50 characters or fewer, including
+   the type and optional scope. Prefer clarity over clever compression.
+5. **Draft the body:** Explain what changed and why it matters. Ensure body
+   lines are wrapped at 72 characters or fewer. Do not rely on visual
+   guesswork.
+6. **Validate the footer:** If an external ticket exists, ensure the ticket
+   footer is the final line, with a blank line before it. Use `Refs: #X` or the
+   configured external tracker format for ongoing work, and `Fixes: #X` only
+   when the external ticket is completed by the commit. If no external ticket
+   exists, omit the footer entirely.
+7. **Reject policy violations:** Do not include Copilot trailers, do not stage
+   unrelated files, and do not propose a vague scope that could apply to many
+   unrelated changes.
+
+**Mental lint before proposing:**
+
+- Does the scope match the staged diff's real area?
+- Is the title 50 characters or fewer?
+- Are body lines wrapped at 72 characters or fewer?
+- Does the body explain what and why?
+- If an external ticket exists, is the ticket footer the final line?
+- If no external ticket exists, did you omit the footer entirely?
+- Are you avoiding internal Taskwarrior UUIDs and local task IDs in the footer?
+- Do not include Copilot trailers.
 
 ## 📋 Operational Standards
 


### PR DESCRIPTION
Document a commit construction checklist so agents classify the changed area, choose scope carefully, and validate title, body, and footer format before proposing a commit.

Clarify that commit footers are only for external GitHub, Bitbucket, or Jira tickets. Internal Taskwarrior UUIDs and local task IDs must not be used in Git commit messages.

Fixes: #60